### PR TITLE
Cascade removed, add some more tests

### DIFF
--- a/src/main/java/io/tackle/controls/entities/Stakeholder.java
+++ b/src/main/java/io/tackle/controls/entities/Stakeholder.java
@@ -1,14 +1,12 @@
 package io.tackle.controls.entities;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.tackle.commons.entities.AbstractEntity;
 import io.tackle.commons.annotations.Filterable;
+import io.tackle.commons.entities.AbstractEntity;
 import org.hibernate.annotations.ResultCheckStyle;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.ManyToMany;
@@ -32,11 +30,11 @@ public class Stakeholder extends AbstractEntity {
     @Filterable
     public String email;
     @OneToMany(mappedBy = "owner", fetch = FetchType.LAZY)
-    @JsonBackReference
+    @JsonBackReference("businessServicesReference")
     public List<BusinessService> businessServices = new ArrayList<>();
 
-    @ManyToMany(mappedBy="stakeholders", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
-    @JsonIgnore
+    @ManyToMany(mappedBy="stakeholders", fetch = FetchType.LAZY)
+    @JsonBackReference("stakeholderGroupsReference")
     public List<StakeholderGroup> stakeholderGroups = new ArrayList<>();
 
     @PreRemove

--- a/src/main/java/io/tackle/controls/entities/StakeholderGroup.java
+++ b/src/main/java/io/tackle/controls/entities/StakeholderGroup.java
@@ -1,15 +1,11 @@
 package io.tackle.controls.entities;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import io.tackle.commons.annotations.Filterable;
 import io.tackle.commons.entities.AbstractEntity;
 import org.hibernate.annotations.ResultCheckStyle;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
@@ -30,17 +26,14 @@ public class StakeholderGroup extends AbstractEntity {
     @Filterable
     public String description;
 
-    @ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
             name = "stakeholdergroup_stakeholders",
             joinColumns = {@JoinColumn(name = "group_id")},
             inverseJoinColumns = {@JoinColumn(name = "stakeholder_id")}
     )
-    @JsonManagedReference
+    @Filterable(filterName = "stakeholders.displayName")
     public List<Stakeholder> stakeholders = new ArrayList<>();
-
-    @Filterable
-    public Integer members;
 
     @PreRemove
     private void preRemove() {

--- a/src/main/resources/db/test-data/V20210312.2__insert_stakeholdergroup-stakeholders.sql
+++ b/src/main/resources/db/test-data/V20210312.2__insert_stakeholdergroup-stakeholders.sql
@@ -1,2 +1,3 @@
 INSERT INTO stakeholdergroup_stakeholders (group_id, stakeholder_id) VALUES (52, 4);
+INSERT INTO stakeholdergroup_stakeholders (group_id, stakeholder_id) VALUES (52, 5);
 INSERT INTO stakeholdergroup_stakeholders (group_id, stakeholder_id) VALUES (53, 5);

--- a/src/main/resources/import-dev.sql
+++ b/src/main/resources/import-dev.sql
@@ -24,3 +24,7 @@ INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updat
 INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'Spring Boot', 18, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
 INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'RHEL 8', 19, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
 INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'Windows Server 2016', 19, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
+INSERT INTO stakeholder_group (id, name, description, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'Managers', 'Managers Group', '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
+INSERT INTO stakeholder_group (id, name, description, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'Engineers', 'Engineers Group', '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
+INSERT INTO stakeholdergroup_stakeholders (group_id, stakeholder_id) VALUES (27, 4);
+INSERT INTO stakeholdergroup_stakeholders (group_id, stakeholder_id) VALUES (28, 3);

--- a/src/test/java/io/tackle/controls/resources/ServicesParameterizedTest.java
+++ b/src/test/java/io/tackle/controls/resources/ServicesParameterizedTest.java
@@ -11,6 +11,7 @@ import io.tackle.commons.testcontainers.PostgreSQLDatabaseTestResource;
 import io.tackle.commons.tests.SecuredResourceTest;
 import io.tackle.controls.entities.JobFunction;
 import io.tackle.controls.entities.Stakeholder;
+import io.tackle.controls.entities.StakeholderGroup;
 import io.tackle.controls.entities.Tag;
 import io.tackle.controls.entities.TagType;
 import org.junit.jupiter.api.DisplayName;
@@ -48,14 +49,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ServicesParameterizedTest extends SecuredResourceTest {
 
     // the 'name' output seems not to work with Quarkus
-    @DisplayName("testListHalEndpoint")
+    @DisplayName("testListEndpoints")
     @ParameterizedTest(name = "{index} ==> Resource ''{0}'' tested is {1}")
     @CsvSource({
-            "stakeholder     , 2, 4::5              , 2 , 4, displayName, Jessica Fletcher::Emmett Brown                              ",
-            "business-service, 3, 1::2::3           , 3 , 4, name       , Home Banking BU::Online Investments service::Credit Cards BS",
-            "job-function    , 5, 6::7::8::9::10    , 12, 5, role       , Business Analyst::Business Service Owner / Manager::Consultant::DBA::Developer / Software Engineer",
-            "tag-type        , 5, 18::19::20        , 6 , 5, colour     , #E8CCCC::#d4e8cc::#cce8e7::#46bdc6::#e8cce4",
-            "tag             , 5, 24::25::26::27::28, 28, 5, name       , COTS::In house::SaaS::Boston (USA)::London (UK)"
+        //   resource path    ,size, IDs               ,tot,linkSize,anotherField, anotherFieldValues
+            "stakeholder      ,   2, 4::5              , 2 ,       4, displayName, Jessica Fletcher::Emmett Brown                              ",
+            "business-service ,   3, 1::2::3           , 3 ,       4, name       , Home Banking BU::Online Investments service::Credit Cards BS",
+            "job-function     ,   5, 6::7::8::9::10    , 12,       5, role       , Business Analyst::Business Service Owner / Manager::Consultant::DBA::Developer / Software Engineer",
+            "tag-type         ,   5, 18::19::20        , 6 ,       5, colour     , #E8CCCC::#d4e8cc::#cce8e7::#46bdc6::#e8cce4",
+            "tag              ,   5, 24::25::26::27::28, 28,       5, name       , COTS::In house::SaaS::Boston (USA)::London (UK)",
+            "stakeholder-group,   3, 52::53::54        , 3 ,       4, description, Managers Group::Engineers Group::Marketing Group"
     })
     public void testListEndpoints(String resource, int size, @ConvertWith(CSVtoArray.class) Integer[] ids, int totalCount, int linkSize,
                                   String anotherFieldName, @ConvertWith(CSVtoArray.class) String[] anotherFieldValues) {
@@ -86,7 +89,7 @@ public class ServicesParameterizedTest extends SecuredResourceTest {
                         format("%s", anotherFieldName), containsInRelativeOrder(anotherFieldValues));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{index} ==> Resource ''{0}'' tested is {1}")
     @MethodSource("provideObjects")
     public void testCreateAndDeleteEndpoint(AbstractEntity entity, String resource) {
         Response response = given()
@@ -132,6 +135,9 @@ public class ServicesParameterizedTest extends SecuredResourceTest {
         consultant.id = 7L;
         stakeholder.jobFunction = consultant;
         stakeholder.email = "another@email.foo";
+        StakeholderGroup marketing = new StakeholderGroup();
+        marketing.id = 54L;
+        stakeholder.stakeholderGroups = Arrays.asList(marketing);
 
         JobFunction ceo = new JobFunction();
         ceo.role = "CEO";
@@ -147,11 +153,23 @@ public class ServicesParameterizedTest extends SecuredResourceTest {
         tag.tagType = parentTagType;
         tag.name = "value";
 
+        StakeholderGroup stakeholderGroup = new StakeholderGroup();
+        stakeholderGroup.name = "name";
+        stakeholderGroup.description = "description";
+        Stakeholder stakeholder1 = new Stakeholder();
+        stakeholder1.id = 4L;
+        Stakeholder jessica = new Stakeholder();
+        jessica.id = 4L;
+        Stakeholder emmett = new Stakeholder();
+        emmett.id = 5L;
+        stakeholderGroup.stakeholders = Arrays.asList(jessica, emmett);
+
         return Stream.of(
                 Arguments.of(stakeholder, "/stakeholder"),
                 Arguments.of(ceo, "/job-function"),
                 Arguments.of(tagType, "/tag-type"),
-                Arguments.of(tag, "/tag")
+                Arguments.of(tag, "/tag"),
+                Arguments.of(stakeholderGroup, "/stakeholder-group")
         );
     }
 

--- a/src/test/java/io/tackle/controls/resources/StakeholderGroupTest.java
+++ b/src/test/java/io/tackle/controls/resources/StakeholderGroupTest.java
@@ -50,16 +50,9 @@ public class StakeholderGroupTest extends SecuredResourceTest {
 
     @Test
     public void testStakeholderGroupListEndpoint() {
-        RestAssured.defaultParser = Parser.JSON;
-        RestAssured.config
-                .objectMapperConfig(new ObjectMapperConfig().jackson2ObjectMapperFactory((type, s) -> new ObjectMapper()
-                                .registerModule(new Jdk8Module())
-                                .registerModule(new JavaTimeModule())
-                        /*.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)*/));
-
         given()
                 .accept("application/json")
-                .queryParam("sort", "id")
+                .queryParam("sort", "-stakeholders.size")
                 .when().get(PATH)
                 .then()
                 .log().all()
@@ -67,7 +60,8 @@ public class StakeholderGroupTest extends SecuredResourceTest {
                 .body("size()", is(3),
                         "id", containsInRelativeOrder(52, 53, 54),
                         "name", containsInRelativeOrder("Managers", "Engineers", "Marketing"),
-                        "createUser", containsInRelativeOrder("<pre-filled>", "<pre-filled>", "<pre-filled>")
+                        "createUser", containsInRelativeOrder("<pre-filled>", "<pre-filled>", "<pre-filled>"),
+                        "[0].stakeholder.size()", is(2)
                 );
     }
 

--- a/src/test/java/io/tackle/controls/resources/StakeholderGroupTest.java
+++ b/src/test/java/io/tackle/controls/resources/StakeholderGroupTest.java
@@ -110,6 +110,22 @@ public class StakeholderGroupTest extends SecuredResourceTest {
                         "createUser", contains("<pre-filled>"),
                         "updateUser", contains("<pre-filled>")
                 );
+
+        given()
+                .accept("application/json")
+                .queryParam("sort", "id")
+                .queryParam("description", "up")
+                .queryParam("stakeholders.displayName", "met")
+                .when().get(PATH)
+                .then()
+                .log().all()
+                .statusCode(200)
+                .body("size()", is(1),
+                        "id", containsInRelativeOrder(53),
+                        "name", containsInRelativeOrder("Engineers"),
+                        "createUser", containsInRelativeOrder("<pre-filled>"),
+                        "stakeholders[0].displayName", containsInRelativeOrder("Emmett Brown")
+                );
     }
 
 /*    @Test


### PR DESCRIPTION
- labels for `JsonBackReference` to avoid conflicts when used multiple times in an entity
- removed `cascade` because, in the end, to add a reference to another entity, the referenced entity must be already created. There's no need to create two related entities at the same time.
- added `@Filterable(filterName = "stakeholders.displayName")` annotation in `StakeholderGroup` for enabling the filter by stakeholder in the stakeholder group web page
- added some sample data into `import-dev.sql` script to help when running Quarkus in dev mode
- added stakeholder group basic test in the parameterized tests in `ServicesParameterizedTest`
- enhanced the `testStakeholderGroupFilteredMultipleParamsWithMultipleValuesListEndpoint` test with a request with the `stakeholders.displayName` parameter to evaluate the stakeholder referenced entity in filtering